### PR TITLE
Correct module name

### DIFF
--- a/coursera_bd/week3/a6_w3_ex1.ipynb
+++ b/coursera_bd/week3/a6_w3_ex1.ipynb
@@ -142,7 +142,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The difference between a transformer and an estimator is state. A transformer is stateless whereas an estimator keeps state. Therefore “VectorAsselmbler” is a transformer since it only need to read row by row. Normalizer, on the other hand need to compute statistics on the dataset before, therefore it is an estimator. An estimator has an additional “fit” function. “OneHotEncoder” has been deprecated in Spark 2.3, therefore please change the code below to use the OneHotEstimator instead of the “OneHotEncoder”.\n",
+    "The difference between a transformer and an estimator is state. A transformer is stateless whereas an estimator keeps state. Therefore “VectorAsselmbler” is a transformer since it only need to read row by row. Normalizer, on the other hand need to compute statistics on the dataset before, therefore it is an estimator. An estimator has an additional “fit” function. “OneHotEncoder” has been deprecated in Spark 2.3, therefore please change the code below to use the “OneHotEncoderEstimator” instead of the “OneHotEncoder”.\n",
     "\n",
     "More information can be found here:\n",
     "http://spark.apache.org/docs/latest/ml-features.html#onehotencoderestimator\n",


### PR DESCRIPTION
There is no OneHotEstimator in pyspark.ml.feature, the correct name is OneHotEncoderEstimator