### PR TITLE
Added an extra comment line to mention skillsnetwork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ### This is the github project for the following Coursera specialization:
+### Previously located on IBM/coursera directory, now renamed IBM/skillsnetwork.
 
 Advanced Data Science with IBM
 


### PR DESCRIPTION
This is to reflect the renaming of the IBM/coursera repository as mentioned in the coursera videos to IBM/skillsnetwork